### PR TITLE
Fix Paper NoSuchMethodError getBukkitEntity() & Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Output/
+/Output_Addons/

--- a/Addon-Doll-v1_20_R2/.gitignore
+++ b/Addon-Doll-v1_20_R2/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Doll-v1_20_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_20_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -12,6 +12,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @Wrapper(wrapping = Entity.class, method = "wrap")
 public class WEntityImpl extends WEntity<Entity> {
 
@@ -48,7 +51,12 @@ public class WEntityImpl extends WEntity<Entity> {
 
     @Override
     public org.bukkit.entity.Entity getBukkitEntity() {
-        return entity.getBukkitEntity();
+        try {
+            Method getBukkitEntityMethod = entity.getClass().getMethod("getBukkitEntity");
+            return (org.bukkit.entity.Entity) getBukkitEntityMethod.invoke(entity);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Entity getInstance() {

--- a/Addon-Doll-v1_20_R3/.gitignore
+++ b/Addon-Doll-v1_20_R3/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Doll-v1_20_R3/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_20_R3/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -12,6 +12,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @Wrapper(wrapping = Entity.class, method = "wrap")
 public class WEntityImpl extends WEntity<Entity> {
 
@@ -48,7 +51,12 @@ public class WEntityImpl extends WEntity<Entity> {
 
     @Override
     public org.bukkit.entity.Entity getBukkitEntity() {
-        return entity.getBukkitEntity();
+        try {
+            Method getBukkitEntityMethod = entity.getClass().getMethod("getBukkitEntity");
+            return (org.bukkit.entity.Entity) getBukkitEntityMethod.invoke(entity);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Entity getInstance() {

--- a/Addon-Doll-v1_20_R4/.gitignore
+++ b/Addon-Doll-v1_20_R4/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Doll-v1_20_R4/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_20_R4/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -12,6 +12,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @Wrapper(wrapping = Entity.class, method = "wrap")
 public class WEntityImpl extends WEntity<Entity> {
 
@@ -48,7 +51,12 @@ public class WEntityImpl extends WEntity<Entity> {
 
     @Override
     public org.bukkit.entity.Entity getBukkitEntity() {
-        return entity.getBukkitEntity();
+        try {
+            Method getBukkitEntityMethod = entity.getClass().getMethod("getBukkitEntity");
+            return (org.bukkit.entity.Entity) getBukkitEntityMethod.invoke(entity);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Entity getInstance() {

--- a/Addon-Doll-v1_21_R1/.gitignore
+++ b/Addon-Doll-v1_21_R1/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Doll-v1_21_R1/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_21_R1/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -12,6 +12,9 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 @Wrapper(wrapping = Entity.class, method = "wrap")
 public class WEntityImpl extends WEntity<Entity> {
 
@@ -48,7 +51,12 @@ public class WEntityImpl extends WEntity<Entity> {
 
     @Override
     public org.bukkit.entity.Entity getBukkitEntity() {
-        return entity.getBukkitEntity();
+        try {
+            Method getBukkitEntityMethod = entity.getClass().getMethod("getBukkitEntity");
+            return (org.bukkit.entity.Entity) getBukkitEntityMethod.invoke(entity);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Entity getInstance() {

--- a/Addon-Doll-v1_21_R2/.gitignore
+++ b/Addon-Doll-v1_21_R2/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Doll-v1_21_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_21_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -2,7 +2,6 @@ package me.autobot.addonDoll.wrapper;
 
 import me.autobot.addonDoll.action.PackPlayerImpl;
 import me.autobot.playerdoll.api.action.pack.AbsPackPlayer;
-import me.autobot.playerdoll.api.ReflectionUtil;
 import me.autobot.playerdoll.api.wrapper.Wrapper;
 import me.autobot.playerdoll.api.wrapper.WrapperRegistry;
 import me.autobot.playerdoll.api.wrapper.builtin.WEntity;

--- a/Addon-Doll-v1_21_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
+++ b/Addon-Doll-v1_21_R2/src/main/java/me/autobot/addonDoll/wrapper/WEntityImpl.java
@@ -2,6 +2,7 @@ package me.autobot.addonDoll.wrapper;
 
 import me.autobot.addonDoll.action.PackPlayerImpl;
 import me.autobot.playerdoll.api.action.pack.AbsPackPlayer;
+import me.autobot.playerdoll.api.ReflectionUtil;
 import me.autobot.playerdoll.api.wrapper.Wrapper;
 import me.autobot.playerdoll.api.wrapper.WrapperRegistry;
 import me.autobot.playerdoll.api.wrapper.builtin.WEntity;
@@ -11,6 +12,9 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 @Wrapper(wrapping = Entity.class, method = "wrap")
 public class WEntityImpl extends WEntity<Entity> {
@@ -48,7 +52,12 @@ public class WEntityImpl extends WEntity<Entity> {
 
     @Override
     public org.bukkit.entity.Entity getBukkitEntity() {
-        return entity.getBukkitEntity();
+        try {
+            Method getBukkitEntityMethod = entity.getClass().getMethod("getBukkitEntity");
+            return (org.bukkit.entity.Entity) getBukkitEntityMethod.invoke(entity);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Entity getInstance() {

--- a/Addon-Folia/.gitignore
+++ b/Addon-Folia/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Wrapper-1202_1211/.gitignore
+++ b/Addon-Wrapper-1202_1211/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/Addon-Wrapper-1212/.gitignore
+++ b/Addon-Wrapper-1212/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/PlayerDoll-API/.gitignore
+++ b/PlayerDoll-API/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath

--- a/PlayerDoll-Core/.gitignore
+++ b/PlayerDoll-Core/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/build/
+/bin/
+/.classpath


### PR DESCRIPTION
Start from 1.20.5, Paper stop relocating CraftBukkit packages.
When players execute doll attack command, an error https://pastebin.com/ruxjEQaM occured.
We should use Reflection suggested in https://docs.papermc.io/paper/dev/internals#reflection
Tested on different version, also on spigot server.